### PR TITLE
switch from .idx to .tbi for compressed vcf files

### DIFF
--- a/tools/gatk_baserecalibrator.cwl.yaml
+++ b/tools/gatk_baserecalibrator.cwl.yaml
@@ -31,7 +31,7 @@ inputs:
     inputBinding:
       prefix: --known_snp_vcf_path
       secondaryFiles:
-        - ".idx"
+        - ".tbi"
       
   - id: "#reference_fasta_path"
     type: File

--- a/tools/gatk_indelrealigner.cwl.yaml
+++ b/tools/gatk_indelrealigner.cwl.yaml
@@ -32,6 +32,9 @@ inputs:
     type: File
     inputBinding:
       prefix: --known_indel_vcf_path
+      secondaryFiles:
+        - ".tbi"
+
 
   - id: "#reference_fasta_path"
     type: File

--- a/tools/gatk_realignertargetcreator.cwl.yaml
+++ b/tools/gatk_realignertargetcreator.cwl.yaml
@@ -33,7 +33,7 @@ inputs:
     inputBinding:
       prefix: --known_indel_vcf_path
       secondaryFiles:
-        - ".idx"
+        - ".tbi"
 
   - id: "#reference_fasta_path"
     type: File


### PR DESCRIPTION
We are using compressed VCFs now, which have an index file extension of `.tbi` rather than `.idx`
