### PR TITLE
update status table with COMPLETE, then remove cwltool

### DIFF
--- a/slurm_sh/coclean_template.sh
+++ b/slurm_sh/coclean_template.sh
@@ -509,8 +509,8 @@ function main()
     generate_bai_files "${data_dir}" "${BAM_URL_ARRAY}" "${CASE_ID}" "${GIT_CWL_REPO}" "${BUILDBAMINDEX_TOOL}" "${DB_CRED_URL}" "${S3_CFG_PATH}"
     run_coclean "${data_dir}" "${BAM_URL_ARRAY}" "${CASE_ID}" "${COCLEAN_WORKFLOW}" "${REFERENCE_GENOME}" "${KNOWN_INDEL_VCF}" "${KNOWN_SNP_VCF}" "${THREAD_COUNT}" "${GIT_CWL_REPO}" "${index_dir}" "${DB_CRED_URL}" "${S3_CFG_PATH}"
     upload_coclean_results "${CASE_ID}" "${BAM_URL_ARRAY}" "${S3_OUT_BUCKET}" "${S3_LOG_BUCKET}" "${S3_CFG_PATH}" "${data_dir}"
-    #remove_data "${data_dir}" "${CASE_ID}"
     queue_status_update "${data_dir}" "${QUEUE_STATUS_TOOL}" "${S3_CFG_PATH}" "${DB_CRED_URL}" "${GIT_CWL_REPO}" "${GIT_CWL_HASH}" "${CASE_ID}" "${BAM_URL_ARRAY}" "COMPLETE" "coclean_caseid_queue" "${S3_OUT_BUCKET}"
+    remove_data "${data_dir}" "${CASE_ID}"
 }
 
 main "$@"


### PR DESCRIPTION
cwltool should not be removed before updating status table with COMPLETE, as cwltool is needed to run `queue_status` docker.
