### PR TITLE
resolves OPS-269 removing last references to gdc-api.nci.nih.gov ahea…

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,16 +119,16 @@ The following steps are tested on Ubuntu 14.04. Newer Ubuntu versions, and other
 
      or (2) pull modified data from gdc:
 
-        $ wget https://gdc-api.nci.nih.gov/data/4ba1c087-ec80-47c4-a9d5-e9bb9933fef4 -O dbsnp_144.hg38.vcf.gz
+        $ wget https://api.gdc.cancer.gov/data/4ba1c087-ec80-47c4-a9d5-e9bb9933fef4 -O dbsnp_144.hg38.vcf.gz
 
     reference genome:
 
-        $ wget https://gdc-api.nci.nih.gov/data/62f23fad-0f24-43fb-8844-990d531947cf
+        $ wget https://api.gdc.cancer.gov/data/62f23fad-0f24-43fb-8844-990d531947cf
         tar xvf 62f23fad-0f24-43fb-8844-990d531947cf
 
     bwa indexed genome:
 
-        $ wget https://gdc-api.nci.nih.gov/data/964cbdac-1043-4fae-b068-c3a65d992f6b
+        $ wget https://api.gdc.cancer.gov/data/964cbdac-1043-4fae-b068-c3a65d992f6b
         tar xvf 964cbdac-1043-4fae-b068-c3a65d992f6b
 
 14. Get example data: 1 readgroup BAM which uses `bwa mem`
@@ -148,7 +148,7 @@ The following steps are tested on Ubuntu 14.04. Newer Ubuntu versions, and other
 
         22 readgroup BAM which uses `bwa mem` (all readgroup reads > 70bp; PE and SE reads)
         $ cd /mnt/SCRATCH/
-        $ wget https://gdc-api.nci.nih.gov/data/5a8a9f0b-9121-42c0-a38d-c6510e2065c1 -O C835.HCC1143.2.bam
+        $ wget https://api.gdc.cancer.gov/data/5a8a9f0b-9121-42c0-a38d-c6510e2065c1 -O C835.HCC1143.2.bam
         $ mkdir /mnt/SCRATCH/ccle
         $ cd /mnt/SCRATCH/ccle
         $ mkdir tmp cache

--- a/tools/gdc_get_object.cwl
+++ b/tools/gdc_get_object.cwl
@@ -28,7 +28,7 @@ arguments:
   - valueFrom: "X-Auth-Token: $(inputs.gdc_token.contents)"
     position: 0
 
-  - valueFrom: https://gdc-api.nci.nih.gov/data/$(inputs.gdc_uuid)
+  - valueFrom: https://api.gdc.cancer.gov/data/$(inputs.gdc_uuid)
     position: 1
 
 baseCommand: [curl, --remote-name, --remote-header-name, --header]

--- a/workflows/dnaseq/etl_http_NA12878.chrom20.ILLUMINA.bwa.CEU.low_coverage.20121211.json
+++ b/workflows/dnaseq/etl_http_NA12878.chrom20.ILLUMINA.bwa.CEU.low_coverage.20121211.json
@@ -1,11 +1,11 @@
 {
     "bam_url": "ftp://ftp-trace.ncbi.nih.gov/1000genomes/ftp/phase3/data/NA12878/alignment/NA12878.chrom20.ILLUMINA.bwa.CEU.low_coverage.20121211.bam",
     "bam_name": "NA12878.chrom20.ILLUMINA.bwa.CEU.low_coverage.20121211.bam",
-    "dbsnp_url": "https://gdc-api.nci.nih.gov/data/4ba1c087-ec80-47c4-a9d5-e9bb9933fef4",
+    "dbsnp_url": "https://api.gdc.cancer.gov/data/4ba1c087-ec80-47c4-a9d5-e9bb9933fef4",
     "dbsnp_name": "dbsnp_144.hg38.vcf.gz",
-    "fasta_url": "https://gdc-api.nci.nih.gov/data/62f23fad-0f24-43fb-8844-990d531947cf",
+    "fasta_url": "https://api.gdc.cancer.gov/data/62f23fad-0f24-43fb-8844-990d531947cf",
     "fasta_name": "GRCh38.d1.vd1.fa.tar.gz",
-    "fasta_bwa_url": "https://gdc-api.nci.nih.gov/data/964cbdac-1043-4fae-b068-c3a65d992f6b",
+    "fasta_bwa_url": "https://api.gdc.cancer.gov/data/964cbdac-1043-4fae-b068-c3a65d992f6b",
     "fasta_bwa_name": "GRCh38.d1.vd1_BWA.tar.gz",
     "thread_count": 8,
     "uuid": "123e4567-e89b-12d3-a456-426655440000"

--- a/workflows/dnaseq/etl_http_NA12878.chrom20.ILLUMINA.bwa.CEU.low_coverage.20121211.yml
+++ b/workflows/dnaseq/etl_http_NA12878.chrom20.ILLUMINA.bwa.CEU.low_coverage.20121211.yml
@@ -1,9 +1,9 @@
 bam_url: ftp://ftp-trace.ncbi.nih.gov/1000genomes/ftp/phase3/data/NA12878/alignment/NA12878.chrom20.ILLUMINA.bwa.CEU.low_coverage.20121211.bam
 bam_name: NA12878.chrom20.ILLUMINA.bwa.CEU.low_coverage.20121211.bam
-dbsnp_url: https://gdc-api.nci.nih.gov/data/4ba1c087-ec80-47c4-a9d5-e9bb9933fef4
+dbsnp_url: https://api.gdc.cancer.gov/data/4ba1c087-ec80-47c4-a9d5-e9bb9933fef4
 dbsnp_name: dbsnp_144.hg38.vcf.gz
-fasta_url: https://gdc-api.nci.nih.gov/data/62f23fad-0f24-43fb-8844-990d531947cf
+fasta_url: https://api.gdc.cancer.gov/data/62f23fad-0f24-43fb-8844-990d531947cf
 fasta_name: GRCh38.d1.vd1.fa.tar.gz
-fasta_bwa_url: https://gdc-api.nci.nih.gov/data/964cbdac-1043-4fae-b068-c3a65d992f6b
+fasta_bwa_url: https://api.gdc.cancer.gov/data/964cbdac-1043-4fae-b068-c3a65d992f6b
 fasta_bwa_name: GRCh38.d1.vd1_BWA.tar.gz
 thread_count: 8


### PR DESCRIPTION
…d of SSL expiring on Jun 17 23:59:59 2018 GMT